### PR TITLE
v1.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BoarBot v1.0.9
+# BoarBot v1.0.10
 
 This is a personal project I've set out to create for a Discord community.
 I've always wanted to make something that makes people happy, so this is it.

--- a/example_config.json
+++ b/example_config.json
@@ -236,6 +236,10 @@
     "noParentChannel": "NO CATEGORY",
     "notValidChannel": "This channel isn't valid! Try a different one! The channel should be a text channel, be not already chosen, and exists in this server.",
     "sentReport": "Successfully sent report!",
+    "deletedData": "Success! Your data will be deleted in 24 hours. If you'd like to cancel this operation, run any BoarBot command within the next 24 hours.",
+    "cancelDelete": "Cancelled the self-wipe process.",
+    "deleteMsgOne": "Are you **absolutely** sure you want to **completely** wipe your data from BoarBot?",
+    "deleteMsgTwo": "**THIS WILL DELETE EVERYTHING!** All of your progress will be gone forever and will not be recoverable. So once again, are you **ABSOLUTELY** sure you want to **COMPLETELY** wipe your data from BoarBot?",
     "defaultSelectPlaceholder": "UNSELECTED",
     "emptySelect": "None",
     "channelOptionLabel": "#%@ [%@]",
@@ -1217,6 +1221,33 @@
               }
             ]
           }
+        ]
+      },
+      "selfWipe": {
+        "name": "self-wipe",
+        "description": "Wipe your profile clean. Deletes all stored data tied to your account.",
+        "componentFields": [
+          [
+            {
+              "type": 1,
+              "components": [
+                {
+                  "type": 2,
+                  "customId": "SELF_WIPE_DELETE",
+                  "label": "DELETE",
+                  "style": 4,
+                  "disabled": true
+                },
+                {
+                  "type": 2,
+                  "customId": "SELF_WIPE_CANCEL",
+                  "label": "Cancel",
+                  "style": 2,
+                  "disabled": false
+                }
+              ]
+            }
+          ]
         ]
       }
     },

--- a/src/main/typescript/bot/config/StringConfig.ts
+++ b/src/main/typescript/bot/config/StringConfig.ts
@@ -184,6 +184,10 @@ export class StringConfig {
     public readonly noParentChannel: string = ' ';
     public readonly notValidChannel: string = ' ';
     public readonly sentReport: string = ' ';
+    public readonly deletedData: string = ' ';
+    public readonly cancelDelete: string = ' ';
+    public readonly deleteMsgOne: string = ' ';
+    public readonly deleteMsgTwo: string = ' ';
     public readonly defaultSelectPlaceholder: string = ' ';
     public readonly emptySelect: string = ' ';
     public readonly channelOptionLabel: string = ' ';

--- a/src/main/typescript/bot/handlers/ConfigHandler.ts
+++ b/src/main/typescript/bot/handlers/ConfigHandler.ts
@@ -148,7 +148,7 @@ export class ConfigHandler {
             passed = false;
         }
 
-        return passed;
+        return passed || parsedConfig.maintenanceMode;
     }
 
     /**

--- a/src/main/typescript/commands/boar_dev/BanSubcommand.ts
+++ b/src/main/typescript/commands/boar_dev/BanSubcommand.ts
@@ -7,7 +7,7 @@ import {GuildData} from '../../util/data/global/GuildData';
 import {StringConfig} from '../../bot/config/StringConfig';
 import {Queue} from '../../util/interactions/Queue';
 import {LogDebug} from '../../util/logging/LogDebug';
-import {BoarUser} from '../../util/boar/BoarUser';
+import {DataHandlers} from '../../util/data/DataHandlers';
 
 /**
  * {@link BanSubcommand BanSubcommand.ts}
@@ -56,9 +56,9 @@ export default class BanSubcommand implements Subcommand {
 
         await Queue.addQueue(async () => {
             try {
-                const boarUser = new BoarUser(userInput, true);
-                boarUser.stats.general.unbanTime = Date.now() + timeInput * 60 * 60 * 1000;
-                boarUser.updateUserData();
+                const globalData = DataHandlers.getGlobalData();
+                globalData.bannedUsers[userInput.id] = Date.now() + timeInput * 60 * 60 * 1000;
+                DataHandlers.saveGlobalData(globalData);
 
                 await Replies.handleReply(
                     interaction, this.config.stringConfig.banSuccess
@@ -68,6 +68,6 @@ export default class BanSubcommand implements Subcommand {
             } catch (err: unknown) {
                 await LogDebug.handleError(err, this.interaction);
             }
-        }, this.interaction.id + interaction.user.id);
+        }, this.interaction.id + 'global');
     }
 }

--- a/src/main/typescript/util/boar/BoarUser.ts
+++ b/src/main/typescript/util/boar/BoarUser.ts
@@ -189,6 +189,10 @@ export class BoarUser {
             this.stats.general.boarStreak = 0;
         }
 
+        if (this.stats.general.unbanTime !== undefined) {
+            this.stats.general.unbanTime = undefined;
+        }
+
         let uniques = 0;
 
         for (const boarID of Object.keys(this.itemCollection.boars)) {

--- a/src/main/typescript/util/data/DataHandlers.ts
+++ b/src/main/typescript/util/data/DataHandlers.ts
@@ -9,6 +9,7 @@ import {StringConfig} from '../../bot/config/StringConfig';
 import {BoarUser} from '../boar/BoarUser';
 import {GlobalData} from './global/GlobalData';
 import {ItemData} from './global/ItemData';
+import {BoardData} from './global/BoardData';
 
 /**
  * {@link DataHandlers DataHandlers.ts}
@@ -41,6 +42,11 @@ export class DataHandlers {
 
             for (const powerupID of Object.keys(config.itemConfigs.powerups)) {
                 globalData.itemData.powerups[powerupID] = new ItemData;
+            }
+
+            for (let i=0; i<config.commandConfigs.boar.top.args[0].choices.length; i++) {
+                const boardID = config.commandConfigs.boar.top.args[0].choices[i].value;
+                globalData.leaderboardData[boardID] = new BoardData;
             }
 
             DataHandlers.saveGlobalData(globalData);

--- a/src/main/typescript/util/data/global/GlobalData.ts
+++ b/src/main/typescript/util/data/global/GlobalData.ts
@@ -13,5 +13,6 @@ import {BoardData} from './BoardData';
 export class GlobalData {
     public itemData: ItemsData = new ItemsData;
     public leaderboardData: Record<string, BoardData> = {};
+    public bannedUsers: Record<string, number | undefined> = {};
     public nextPowerup = 0;
 }

--- a/src/main/typescript/util/data/userdata/stats/GeneralStats.ts
+++ b/src/main/typescript/util/data/userdata/stats/GeneralStats.ts
@@ -20,5 +20,6 @@ export class GeneralStats {
     public highestMulti = 0;
     public notificationsOn = false;
     public notificationChannel = '';
-    public unbanTime = 0;
+    public unbanTime: number | undefined; // No longer supported
+    public deletionTime: number | undefined;
 }


### PR DESCRIPTION
- Bans are now stored in a global file instead of user files
- Config can be refreshed even if wrong in maintenance mode
- Made a fix with a fresh global file not having leaderboard data
- Updated example_config.json
- Self-wipe now waits 24 hours before wiping