### PR TITLE
v1.1.1

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -292,7 +292,7 @@
     "imageName": "unknown",
     "fontName": "Minecraft",
     "commandDebugPrefix": "%@ [%@%@]\n",
-    "commitLink": "https://api.github.com/repos/WeslayCodes/BoarBot/commits/main",
+    "pullLink": "https://api.github.com/repos/WeslayCodes/BoarBot/pulls",
     "githubImg": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
   },
   "numberConfig": {

--- a/src/main/python/user_animated_overlay.py
+++ b/src/main/python/user_animated_overlay.py
@@ -29,12 +29,13 @@ gifter_user_tag = sys.argv[9]
 
 item_assets = path_config['itemAssets']
 other_assets = path_config['otherAssets']
+font_assets = path_config['fontAssets']
 temp_item_assets = path_config['tempItemAssets']
 
 # Configured asset file paths
 
 circle_mask_path = other_assets + path_config['circleMask']
-font_path = other_assets + path_config['mainFont']
+font_path = font_assets + path_config['mainFont']
 
 # Configured colors
 

--- a/src/main/typescript/bot/config/StringConfig.ts
+++ b/src/main/typescript/bot/config/StringConfig.ts
@@ -219,6 +219,6 @@ export class StringConfig {
     public readonly imageName: string = ' ';
     public readonly fontName: string = ' ';
     public readonly commandDebugPrefix: string = ' ';
-    public readonly commitLink: string = ' ';
+    public readonly pullLink: string = ' ';
     public readonly githubImg: string = ' ';
 }

--- a/src/main/typescript/commands/boar/CollectionSubcommand.ts
+++ b/src/main/typescript/commands/boar/CollectionSubcommand.ts
@@ -634,7 +634,7 @@ export default class CollectionSubcommand implements Subcommand {
         if (dataChanged) {
             LogDebug.log(
                 `Failed cloning of '${this.allBoars[this.curPage].id} due to data changing'`,
-                this.config, this.firstInter, true
+                this.config, this.firstInter
             );
 
             await Replies.handleReply(
@@ -658,7 +658,7 @@ export default class CollectionSubcommand implements Subcommand {
         } else {
             LogDebug.log(
                 `Failed cloning of '${this.allBoars[this.curPage].id}'`,
-                this.config, this.firstInter, true
+                this.config, this.firstInter
             );
 
             await Replies.handleReply(

--- a/src/main/typescript/util/boar/BoarUser.ts
+++ b/src/main/typescript/util/boar/BoarUser.ts
@@ -105,8 +105,8 @@ export class BoarUser {
 
         this.stats.quests.progress[dailyQuestIndex] += this.stats.general.numDailies -
             userData.stats.general.numDailies;
-        this.stats.quests.progress[cloneBoarsIndex] += this.itemCollection.powerups.clone.numUsed -
-            userData.itemCollection.powerups.clone.numUsed;
+        this.stats.quests.progress[cloneBoarsIndex] += (this.itemCollection.powerups.clone.numSuccess as number) -
+            (userData.itemCollection.powerups.clone.numSuccess as number);
         this.stats.quests.progress[cloneRarityIndex] += (this.itemCollection.powerups.clone.raritiesUsed as number[])[
                 Math.floor(cloneRarityIndex / 2)
             ] - userData.itemCollection.powerups.clone.raritiesUsed[Math.floor(cloneRarityIndex / 2)];

--- a/src/main/typescript/util/boar/PowerupSpawner.ts
+++ b/src/main/typescript/util/boar/PowerupSpawner.ts
@@ -322,8 +322,7 @@ export class PowerupSpawner {
                 );
             } else if (!hasClaimed && !fullyFailed) {
                 LogDebug.log(
-                    `${inter.user.username} (${inter.user.id}) guessed INCORRECT in Powerup Event`,
-                    config, undefined, true
+                    `${inter.user.username} (${inter.user.id}) guessed INCORRECT in Powerup Event`, config
                 );
 
                 if (this.failers.has(inter.user.id)) {

--- a/src/main/typescript/util/data/global/GitHubData.ts
+++ b/src/main/typescript/util/data/global/GitHubData.ts
@@ -8,5 +8,5 @@
  */
 
 export class GitHubData {
-    public lastCommitSha = '';
+    public lastURL = '';
 }

--- a/src/main/typescript/util/interactions/Queue.ts
+++ b/src/main/typescript/util/interactions/Queue.ts
@@ -32,7 +32,7 @@ export class Queue {
         return new Promise((resolve, reject) => {
             setTimeout(() => {
                 reject('Took too long to run queue item. ID: ' + id);
-            }, 30000);
+            }, 180000);
 
             setInterval(() => {
                 if (!Queue.queues[queueIndex][id])


### PR DESCRIPTION
## Bug fixes and changes
- GitHub update channel now sends the PR instead of the commit (looks better!)
- Fixed failed clones counting toward quests
- Stopped some non-vital logs from being sent to log channel
- Made queue rejection fail after 3 minutes instead of only 30 seconds (prevents errors during peak hours)
- Fixed animated boars not being sent