### PR TITLE
Fixed error in example_config.json

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -2869,7 +2869,7 @@
       "enhancersNeeded": 0,
       "avgClones": 500,
       "boars": [
-        "creator"
+        "supernova"
       ]
     },
     {


### PR DESCRIPTION
Fixed immaculate list to say "supernova" instead of "creator" 