### PR TITLE
v1.1.12 - Fixed bugs reported using /boar report

### DIFF
--- a/src/main/js/commands/boar/CollectionSubcommand.ts
+++ b/src/main/js/commands/boar/CollectionSubcommand.ts
@@ -165,7 +165,7 @@ export default class CollectionSubcommand implements Subcommand {
         } else if (this.curView === View.Normal) {
             // Maps boar search value to its normal view page index
             const normalSearchArr = this.allBoarsSearchArr.map((val: [string, number]) => {
-                    return [val[0], Math.ceil(val[1] / this.config.numberConfig.collBoarsPerPage)] as [string, number];
+                return [val[0], Math.ceil(val[1] / this.config.numberConfig.collBoarsPerPage)] as [string, number];
             });
 
             pageVal = BoarUtils.getClosestName(pageInput.toLowerCase().replace(/\s+/g, ''), normalSearchArr);
@@ -627,6 +627,7 @@ export default class CollectionSubcommand implements Subcommand {
             for (let i=0; i<miraclesActivated; i++) {
                 multiplier += Math.min(Math.ceil(multiplier * 0.1), this.config.numberConfig.miracleIncreaseMax);
             }
+            multiplier--;
 
             // Sends confirmation message
             await Replies.handleReply(

--- a/src/main/js/commands/boar/DailySubcommand.ts
+++ b/src/main/js/commands/boar/DailySubcommand.ts
@@ -132,6 +132,8 @@ export default class DailySubcommand implements Subcommand {
                     boarUser.itemCollection.powerups.miracle.numActive = 0;
                 }
 
+                boarUser.stats.general.highestMulti = Math.max(userMultiplier-1, boarUser.stats.general.highestMulti);
+
                 boarUser.stats.general.boarStreak++;
                 boarUser.stats.general.lastDaily = Date.now();
                 boarUser.stats.general.numDailies++;

--- a/src/main/js/commands/boar/TopSubcommand.ts
+++ b/src/main/js/commands/boar/TopSubcommand.ts
@@ -118,7 +118,7 @@ export default class TopSubcommand implements Subcommand {
             this.curPage = Math.max(Math.min(pageInput-1, this.maxPage), 0);
         } else {
             this.curPage = Math.max(
-                Math.ceil(this.getUserIndex(userInput.id) / this.config.numberConfig.leaderboardNumPlayers), 0
+                Math.ceil(this.getUserIndex(userInput.id) / this.config.numberConfig.leaderboardNumPlayers) - 1, 0
             );
         }
 
@@ -492,7 +492,7 @@ export default class TopSubcommand implements Subcommand {
      * @private
      */
     private getUserIndex(idInput: string): number {
-        let i = 0;
+        let i = 1;
 
         for (const [id] of this.curBoardData) {
             if (id === idInput) return i;

--- a/src/main/js/util/boar/BoarUser.ts
+++ b/src/main/js/util/boar/BoarUser.ts
@@ -307,12 +307,12 @@ export class BoarUser {
         this.stats.general.multiplier = uniques + this.stats.general.highestStreak;
         this.stats.general.multiplier = Math.min(this.stats.general.multiplier, nums.maxPowBase);
 
-        let visualMulti = this.stats.general.multiplier;
+        let visualMulti = this.stats.general.multiplier + 1;
         const numMiraclesActive = this.itemCollection.powerups.miracle.numActive as number;
-
         for (let i=0; i<numMiraclesActive; i++) {
             visualMulti += Math.min(Math.ceil(visualMulti * 0.1), config.numberConfig.miracleIncreaseMax);
         }
+        visualMulti--;
 
         this.stats.general.highestMulti = Math.max(visualMulti, this.stats.general.highestMulti);
 

--- a/src/main/js/util/data/DataHandlers.ts
+++ b/src/main/js/util/data/DataHandlers.ts
@@ -355,6 +355,7 @@ export class DataHandlers {
             for (let i=0; i<(boarUser.itemCollection.powerups.miracle.numActive as number); i++) {
                 multiplier += Math.min(Math.ceil(multiplier * 0.1), config.numberConfig.miracleIncreaseMax);
             }
+            multiplier--;
 
             if (multiplier > 0) {
                 boardsData.multiplier.userData[userID] = [username, multiplier];
@@ -432,8 +433,13 @@ export class DataHandlers {
         const data = this.getGlobalData(GlobalFile.Quest) as QuestData;
         const questIDs = Object.keys(config.questConfigs);
 
-        data.questsStartTimestamp = new Date().setUTCHours(0,0,0,0) -
-            new Date().getUTCDay() * config.numberConfig.oneDay;
+        const date = new Date();
+        date.setMinutes(date.getMinutes() + 1);
+
+        const curDay = date.getUTCDay();
+        const startOfDay = date.setUTCHours(0,0,0,0);
+
+        data.questsStartTimestamp = startOfDay - curDay * config.numberConfig.oneDay;
 
         for (let i=0; i<data.curQuestIDs.length; i++) {
             data.curQuestIDs[i] = questIDs.splice(Math.floor(Math.random() * questIDs.length), 1)[0];

--- a/src/main/js/util/generators/CollectionImageGenerator.ts
+++ b/src/main/js/util/generators/CollectionImageGenerator.ts
@@ -544,6 +544,7 @@ export class CollectionImageGenerator {
                     Math.ceil(multiplier * 0.1), this.config.numberConfig.miracleIncreaseMax
                 );
             }
+            multiplier--;
 
             await CanvasUtils.drawText(
                 ctx,

--- a/src/main/js/util/generators/MarketImageGenerator.ts
+++ b/src/main/js/util/generators/MarketImageGenerator.ts
@@ -394,18 +394,23 @@ export class MarketImageGenerator {
             }
         }
 
-        let rarityColor = colorConfig.font;
+        let nameColor = colorConfig.font;
+        let claimColor = colorConfig.font;
         let isSpecial = false;
         const isSell = page >= this.userBuyOrders.length;
 
-        if (!claimText.includes(strConfig.emptySelect) && orderInfo.type === 'boars' && !isSell) {
+        if (orderInfo.type === 'boars') {
             const rarity = BoarUtils.findRarity(orderInfo.id, this.config);
-            rarityColor = colorConfig['rarity' + rarity[0]];
+            nameColor = colorConfig['rarity' + rarity[0]];
             isSpecial = rarity[1].name === 'Special' && rarity[0] !== 0;
-        } else if (!claimText.includes(strConfig.emptySelect) && orderInfo.type === 'powerup' && !isSell) {
-            rarityColor = colorConfig.powerup;
-        } else if (claimText.includes('$')) {
-            rarityColor = colorConfig.bucks;
+        } else if (orderInfo.type === 'powerups') {
+            nameColor = colorConfig.powerup;
+        }
+
+        if (claimText.includes('$')) {
+            claimColor = colorConfig.bucks;
+        } else if (!claimText.includes(strConfig.emptySelect)) {
+            claimColor = nameColor;
         }
 
         const underlay = pathConfig.otherAssets + pathConfig.marketOrdersUnderlay;
@@ -436,10 +441,10 @@ export class MarketImageGenerator {
             true,
             [
                 this.config.itemConfigs[orderInfo.type][orderInfo.id].name + (isSpecial
-                ? ' #' + orderInfo.data.editions[0]
-                : '')
+                    ? ' #' + orderInfo.data.editions[0]
+                    : '')
             ],
-            [rarityColor]
+            [nameColor]
         );
 
         await CanvasUtils.drawText(
@@ -487,7 +492,7 @@ export class MarketImageGenerator {
             ctx, strConfig.marketOrdClaimLabel, nums.marketOrdClaimLabelPos, mediumFont, 'center', colorConfig.font
         );
         await CanvasUtils.drawText(
-            ctx, claimText, nums.marketOrdClaimPos, smallMediumFont, 'center', rarityColor, nums.marketOrdClaimWidth
+            ctx, claimText, nums.marketOrdClaimPos, smallMediumFont, 'center', claimColor, nums.marketOrdClaimWidth
         );
 
         return new AttachmentBuilder(canvas.toBuffer('image/png'), { name: `${strConfig.defaultImageName}.png` });

--- a/src/main/js/util/generators/QuestsImageGenerator.ts
+++ b/src/main/js/util/generators/QuestsImageGenerator.ts
@@ -41,7 +41,7 @@ export class QuestsImageGenerator {
         const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
 
         const startDay = new Date(questData.questsStartTimestamp);
-        const endDay = new Date(questData.questsStartTimestamp + nums.oneDay * 7);
+        const endDay = new Date(questData.questsStartTimestamp + nums.oneDay * 6);
 
         const startDayStr = months[startDay.getUTCMonth()] + ' ' + startDay.getUTCDate();
         const endDayStr = months[endDay.getUTCMonth()] + ' ' + endDay.getUTCDate();


### PR DESCRIPTION
## Bug Fixes & Changes
- Number of boar blessings from miracle charms is now ACTUALLY accurate
  - Before, it would say you had one more blessing than you were supposed to have
- Fixed leaderboard page being incorrect sometimes
  - When searching a user, it would sometimes bring you to the page after the one they were on
- Highest boar blessings is now updated when activating miracle charms on /boar daily
- Fixed quests having the wrong start timestamp
  - This fixes the problem where quests changed but progress from previous quests was maintained
- Fixed several coloring issues in orders view of market
- Fixed "EXPIRED" being on the same line as how long an order was listed sometimes
- Boar quest date range is no longer misleading